### PR TITLE
com_zimbra_undosend: add double quote in fr properties

### DIFF
--- a/Zimlet/src/zimlet/com_zimbra_undosend/com_zimbra_undosend_fr.properties
+++ b/Zimlet/src/zimlet/com_zimbra_undosend/com_zimbra_undosend_fr.properties
@@ -35,6 +35,6 @@ UndoSendZimlet_links = {0} ou {1}
 # Preferences dialog.
 #
 UndoSendZimlet_PrefLabel = Annuler Envoyer pr\u00e9f\u00e9rences
-UndoSendZimlet_PrefDescription = Diff\u00e9rer l'envoi des messages de {0} secondes
+UndoSendZimlet_PrefDescription = Diff\u00e9rer l''envoi des messages de {0} secondes
 UndoSendZimlet_PrefInvalidValue = Vous devez sp\u00e9cifier une valeur sup\u00e9rieure \u00e0 z\u00e9ro.
 

--- a/Zimlet/src/zimlet/com_zimbra_undosend/com_zimbra_undosend_fr_CA.properties
+++ b/Zimlet/src/zimlet/com_zimbra_undosend/com_zimbra_undosend_fr_CA.properties
@@ -35,5 +35,5 @@ UndoSendZimlet_links = {0} ou {1}
 # Preferences dialog.
 #
 UndoSendZimlet_PrefLabel = Annuler les pr\u00e9f\u00e9rences d'envoi
-UndoSendZimlet_PrefDescription = Diff\u00e9rer l'envoi des messages de {0} secondes
+UndoSendZimlet_PrefDescription = Diff\u00e9rer l''envoi des messages de {0} secondes
 UndoSendZimlet_PrefInvalidValue = Vous devez pr\u00e9ciser une valeur sup\u00e9rieure \u00e0 z\u00e9ro.


### PR DESCRIPTION
mandatory with fr translation (not tested with other language).